### PR TITLE
Allow to create private anonymous Gists

### DIFF
--- a/gist.js
+++ b/gist.js
@@ -121,11 +121,6 @@ function version() {
 
 function main() {
   debug('main start')
-  if (anon && private) {
-    console.error('Cannot create private anonymous gists')
-    process.exit(1)
-  }
-
   if (prune && !edit) {
     console.error('--prune requires a --edit argument')
     process.exit(1)


### PR DESCRIPTION
Looks like the Gist API totally supports this, and the only limitation was this condition in the code. I commented it and it worked seamlessly to create a private anonymous gist with `gist -p -a`, hence this PR. :smile: